### PR TITLE
Add Distributed Clock (DC) synchronization support in EthercatManager

### DIFF
--- a/CiA402MotionControl/CiA402MotionControl.cpp
+++ b/CiA402MotionControl/CiA402MotionControl.cpp
@@ -533,11 +533,11 @@ struct CiA402MotionControl::Impl
             }
 
             yDebug("%s: Joint %zu: max current %u ‰ → %f A. Torque constant %f Nm/A",
-                    kClassName.data(),
-                    j,
-                    maxPermille,
-                    (double(maxPermille) / 1000.0) * ratedCurrentA,
-                    this->torqueConstants[j]);
+                   kClassName.data(),
+                   j,
+                   maxPermille,
+                   (double(maxPermille) / 1000.0) * ratedCurrentA,
+                   this->torqueConstants[j]);
 
             maxCurrentsA[j] = (double(maxPermille) / 1000.0) * ratedCurrentA;
         }
@@ -1544,6 +1544,16 @@ bool CiA402MotionControl::open(yarp::os::Searchable& cfg)
     if (ecErr != ::CiA402::EthercatManager::Error::NoError)
     {
         yError("%s: EtherCAT init failed (%d)", Impl::kClassName.data(), static_cast<int>(ecErr));
+        return false;
+    }
+
+    // Enable Distributed Clocks (SYNC0 only) with cycle = thread period
+    const uint32_t cycleNs = static_cast<uint32_t>(std::llround(this->getPeriod() * 1e9)); // e.g.,
+                                                                                            // 1e6
+    const auto dcErr = m_impl->ethercatManager.enableDCSync0(cycleNs, /*shift_ns=*/0);
+    if (dcErr != ::CiA402::EthercatManager::Error::NoError)
+    {
+        yError("%s: failed to enable DC SYNC0", Impl::kClassName.data());
         return false;
     }
 

--- a/CiA402MotionControl/EthercatManager.cpp
+++ b/CiA402MotionControl/EthercatManager.cpp
@@ -38,6 +38,10 @@ EthercatManager::~EthercatManager()
     {
         m_watchThread.join();
     }
+
+    // disable the syncronized clock
+    this->disableDCSync0();
+
     // Close only if port was opened
     if (m_portOpen)
     {
@@ -476,4 +480,38 @@ std::string EthercatManager::getName(int slaveIndex) const noexcept
 bool EthercatManager::indexValid(int slaveIndex) const noexcept
 {
     return slaveIndex >= 1 && slaveIndex <= m_ctx.slavecount;
+}
+
+EthercatManager::Error EthercatManager::enableDCSync0(uint32_t cycleNs, int32_t shiftNs) noexcept
+{
+    if (!m_initialized)
+    {
+        return Error::NotInitialized;
+    }
+
+    std::lock_guard<std::mutex> lk(m_ioMtx);
+
+    // Ensure DC is configured at bus level (you already call ecx_configdc in init)
+    // Now enable SYNC0 on each slave (SYNC1 disabled)
+    for (int s = 1; s <= m_ctx.slavecount; ++s)
+    {
+        // ecx_dcsync0(ctx, slave, activate, CyclTime, ShiftTime)
+        // Master-mode behavior is handled by the master; slaves just emit SYNC0
+        ecx_dcsync0(&m_ctx, s, true, cycleNs, shiftNs);
+    }
+    return Error::NoError;
+}
+
+EthercatManager::Error EthercatManager::disableDCSync0() noexcept
+{
+    if (!m_initialized)
+    {
+        return Error::NotInitialized;
+    }
+    std::lock_guard<std::mutex> lk(m_ioMtx);
+    for (int s = 1; s <= m_ctx.slavecount; ++s)
+    {
+        ecx_dcsync0(&m_ctx, s, false, 0, 0);
+    }
+    return Error::NoError;
 }

--- a/CiA402MotionControl/EthercatManager.h
+++ b/CiA402MotionControl/EthercatManager.h
@@ -252,7 +252,26 @@ public:
     template <typename T>
     Error writeSDO(int slaveIndex, uint16_t idx, uint8_t subIdx, const T& value) noexcept;
 
+    /**
+     * @brief Get the name of a slave device.
+     * @param slaveIndex 1-based slave index.
+     * @return Slave name as a string.
+     */
     std::string getName(int slaveIndex) const noexcept;
+
+    /**
+     * @brief Enable DC Sync0 for a slave.
+     * @param cycleNs Sync cycle time in nanoseconds.
+     * @param shiftNs Sync phase shift in nanoseconds.
+     * @return Error::NoError on success; an error code otherwise.
+     */
+    Error enableDCSync0(uint32_t cycleNs, int32_t shiftNs = 0) noexcept;
+
+    /**
+     * @brief Disable DC Sync0 for a slave.
+     * @return Error::NoError on success; an error code otherwise.
+     */
+    Error disableDCSync0() noexcept;
 
 private:
     /** @brief Background error/AL status monitor loop. */


### PR DESCRIPTION
This PR adds **Distributed Clock (DC) synchronization support** to `EthercatManager`.

* Introduced `enableDCSync0(cycleNs, shiftNs=0)` and `disableDCSync0()` APIs.
* On device open, we enable **SYNC0** with the cycle time matching the YARP thread period.
* On shutdown, the destructor now calls `disableDCSync0()` so slaves don’t continue emitting SYNC0 pulses.

Enabling DC ensures that all SOMANET drives share the same clock and update cyclic setpoints (e.g. CST/CSP/CSV) **at the same instant**. This removes inter-joint jitter, reduces vibration and torque spikes, and is essential for stable torque control on humanoid robots. The clean teardown avoids leaving drives in an inconsistent sync state.

Tested with Synapticon SOMANET Circulo, which officially supports DC/SYNC0