### PR TITLE
Add interaction mode functionality to CiA402MotionControl driver

### DIFF
--- a/device/CiA402MotionControl/CiA402MotionControl.cpp
+++ b/device/CiA402MotionControl/CiA402MotionControl.cpp
@@ -271,6 +271,10 @@ struct CiA402MotionControl::Impl
 
     bool opRequested{false}; // true after the first run() call
 
+    /** Dummy interaction mode for all the joints */
+    yarp::dev::InteractionModeEnum dummyInteractionMode{
+        yarp::dev::InteractionModeEnum::VOCAB_IM_STIFF};
+
     Impl() = default;
     ~Impl() = default;
 
@@ -4427,6 +4431,110 @@ bool CiA402MotionControl::getVelLimits(int axis, double* min, double* max)
     // not implemented yet
     constexpr auto logPrefix = "[getVelLimits] ";
     yCError(CIA402, "%s: The getVelLimits function is not implemented", logPrefix);
+    return false;
+}
+
+bool CiA402MotionControl::getInteractionMode(int axis, yarp::dev::InteractionModeEnum* mode)
+{
+    if (!mode)
+    {
+        yCError(CIA402, "%s: null pointer", Impl::kClassName.data());
+        return false;
+    }
+
+    *mode = m_impl->dummyInteractionMode;
+    return true;
+}
+
+bool CiA402MotionControl::getInteractionModes(int n_joints,
+                                              int* joints,
+                                              yarp::dev::InteractionModeEnum* modes)
+{
+    if (!joints || !modes || n_joints <= 0)
+    {
+        yCError(CIA402, "%s: invalid args", Impl::kClassName.data());
+        return false;
+    }
+
+    for (int k = 0; k < n_joints; ++k)
+    {
+        if (joints[k] < 0 || joints[k] >= static_cast<int>(m_impl->numAxes))
+        {
+            yCError(CIA402, "%s: joint %d out of range", Impl::kClassName.data(), joints[k]);
+            return false;
+        }
+        modes[k] = m_impl->dummyInteractionMode;
+    }
+    return true;
+}
+
+bool CiA402MotionControl::getInteractionModes(yarp::dev::InteractionModeEnum* modes)
+{
+    if (modes == nullptr)
+    {
+        yCError(CIA402, "%s: null pointer", Impl::kClassName.data());
+        return false;
+    }
+
+    for (size_t j = 0; j < m_impl->numAxes; ++j)
+    {
+        modes[j] = m_impl->dummyInteractionMode;
+    }
+    return true;
+}
+
+bool CiA402MotionControl::setInteractionMode(int axis, yarp::dev::InteractionModeEnum mode)
+{
+    if (axis < 0 || axis >= static_cast<int>(m_impl->numAxes))
+    {
+        yCError(CIA402, "%s: joint %d out of range", Impl::kClassName.data(), axis);
+        return false;
+    }
+
+    // The interaction mode is not implemented in this driver.
+    yCError(CIA402,
+            "%s: The setInteractionMode function is not implemented",
+            Impl::kClassName.data());
+    return false;
+}
+
+bool CiA402MotionControl::setInteractionModes(int n_joints,
+                                              int* joints,
+                                              yarp::dev::InteractionModeEnum* modes)
+{
+    if (!joints || !modes || n_joints <= 0)
+    {
+        yCError(CIA402, "%s: invalid args", Impl::kClassName.data());
+        return false;
+    }
+
+    for (int k = 0; k < n_joints; ++k)
+    {
+        if (joints[k] < 0 || joints[k] >= static_cast<int>(m_impl->numAxes))
+        {
+            yCError(CIA402, "%s: joint %d out of range", Impl::kClassName.data(), joints[k]);
+            return false;
+        }
+    }
+
+    // The interaction mode is not implemented in this driver.
+    yCError(CIA402,
+            "%s: The setInteractionModes function is not implemented",
+            Impl::kClassName.data());
+    return false;
+}
+
+bool CiA402MotionControl::setInteractionModes(yarp::dev::InteractionModeEnum* modes)
+{
+    if (modes == nullptr)
+    {
+        yCError(CIA402, "%s: null pointer", Impl::kClassName.data());
+        return false;
+    }
+
+    yCError(CIA402,
+            "%s: The setInteractionModes function is not implemented",
+            Impl::kClassName.data());
     return false;
 }
 

--- a/device/CiA402MotionControl/CiA402MotionControl.h
+++ b/device/CiA402MotionControl/CiA402MotionControl.h
@@ -13,6 +13,7 @@
 #include <yarp/dev/IControlMode.h>
 #include <yarp/dev/ICurrentControl.h>
 #include <yarp/dev/IEncodersTimed.h>
+#include <yarp/dev/IInteractionMode.h>
 #include <yarp/dev/IJointFault.h>
 #include <yarp/dev/IMotor.h>
 #include <yarp/dev/IMotorEncoders.h>
@@ -43,7 +44,8 @@ class CiA402MotionControl : public yarp::dev::DeviceDriver,
                             public yarp::dev::ICurrentControl,
                             public yarp::dev::IJointFault,
                             public yarp::dev::IMotor,
-                            public yarp::dev::IControlLimits
+                            public yarp::dev::IControlLimits,
+                            public yarp::dev::IInteractionMode
 {
 public:
     /**
@@ -1189,6 +1191,60 @@ public:
      * @note The velocity limits is not implemented in this driver, so it always returns false.
      */
     bool getVelLimits(int axis, double* min, double* max) override;
+
+    /**
+     * @brief Gets the interaction mode of a specific axis.
+     * @param axis Index of the axis (0-based).
+     * @param mode Pointer to store the interaction mode.
+     * @return true if the mode was successfully retrieved, false otherwise.
+     * @note The interaction mode is not implemented in this driver, it always returns stiff.
+     */
+    bool getInteractionMode(int axis, yarp::dev::InteractionModeEnum* mode) override;
+
+    /**
+     * @brief Gets the interaction modes of a subset of joints.
+     * @param n_joints Number of joints.
+     * @param joints Array of joint indices.
+     * @param modes Array to store the interaction modes.
+     * @return true if the modes were successfully retrieved, false otherwise.
+     */
+    bool
+    getInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes) override;
+
+    /**
+     * @brief Gets the interaction modes of all joints.
+     * @param modes Array to store the interaction modes.
+     * @return true if the modes were successfully retrieved, false otherwise.
+     */
+    bool getInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
+
+    /**
+     * @brief Sets the interaction mode of a specific axis.
+     * @param axis Index of the axis (0-based).
+     * @param mode Interaction mode to set.
+     * @return true if the mode was successfully set, false otherwise.
+     * @note The interaction mode is not implemented in this driver, so it always returns false.
+     */
+    bool setInteractionMode(int axis, yarp::dev::InteractionModeEnum mode) override;
+
+    /**
+     * @brief Sets the interaction modes of a subset of joints.
+     * @param n_joints Number of joints.
+     * @param joints Array of joint indices.
+     * @param modes Array of interaction modes to set.
+     * @return true if the modes were successfully set, false otherwise.
+     * @note The interaction mode is not implemented in this driver, so it always returns false.
+     */
+    bool
+    setInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes) override;
+
+    /**
+     * @brief Sets the interaction modes of all joints.
+     * @param modes Array of interaction modes to set.
+     * @return true if the modes were successfully set, false otherwise.
+     * @note The interaction mode is not implemented in this driver, so it always returns false.
+     */
+    bool setInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
 
 private:
     struct Impl;


### PR DESCRIPTION
Introduce interaction mode methods to the CiA402MotionControl driver, allowing retrieval of interaction modes for joints, while noting that setting modes is not implemented.